### PR TITLE
version 1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 1.0.11 - 2021-08-18
 ### Fixed
 - Fixed issue where `getEntryFeedback()` service was using `.all()` which was limiting the use of `paginate` on the frontend templates.
-- Frontend templates can now use `.feedbackType()` alongside the service.
+- Frontend templates can now use `.feedbackType('[feedback type]')` alongside the service.
 
 ## 1.0.10 - 2021-08-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.11 - 2021-08-18
+### Fixed
+- Fixed issue where `getEntryFeedback()` service was using `.all()` which was limiting the use of `paginate` on the frontend templates.
+- Frontend templates can now use `.feedbackType()` alongside the service.
+
 ## 1.0.10 - 2021-08-16
 ### Added
 - Link to recipe in feedback detail template

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mortscode/feedback",
     "description": "A Craft plugin for user reviews and questions",
     "type": "craft-plugin",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/FeedbackService.php
+++ b/src/services/FeedbackService.php
@@ -12,6 +12,7 @@ namespace mortscode\feedback\services;
 
 use craft\elements\Entry;
 use craft\errors\ElementNotFoundException;
+use mortscode\feedback\elements\db\FeedbackElementQuery;
 use mortscode\feedback\elements\FeedbackElement;
 use mortscode\feedback\enums\FeedbackMessages;
 use mortscode\feedback\enums\FeedbackOrigin;
@@ -51,17 +52,16 @@ class FeedbackService extends Component
      * Get the feedback items belonging to an entry
      *
      * @param int $entryId
-     * @return array [FeedbackElement]
+     * @return FeedbackElementQuery [FeedbackElement]
      */
-    public function getEntryFeedback(int $entryId): array
+    public function getEntryFeedback(int $entryId): FeedbackElementQuery
     {
         return FeedbackElement::find()
             ->where([
                 'entryId' => $entryId,
                 'feedbackStatus' => FeedbackStatus::Approved
             ])
-            ->orderBy(['dateCreated' => SORT_DESC])
-            ->all();
+            ->orderBy(['dateCreated' => SORT_DESC]);
     }
 
     /**

--- a/src/variables/FeedbackVariable.php
+++ b/src/variables/FeedbackVariable.php
@@ -10,14 +10,11 @@
 
 namespace mortscode\feedback\variables;
 
-use craft\errors\ElementNotFoundException;
+
+use mortscode\feedback\elements\db\FeedbackElementQuery;
 use mortscode\feedback\elements\FeedbackElement;
 use mortscode\feedback\Feedback;
 
-use Craft;
-use mortscode\feedback\models\FeedbackModel;
-use Throwable;
-use yii\db\Exception;
 
 /**
  * Feedback Variable
@@ -63,9 +60,9 @@ class FeedbackVariable
      * getEntryFeedback
      *
      * @param int $entryId
-     * @return array[FeedbackElement]
+     * @return FeedbackElementQuery [FeedbackElement]
      */
-    public function getEntryFeedback(int $entryId): array
+    public function getEntryFeedback(int $entryId): FeedbackElementQuery
     {
         return Feedback::$plugin->feedbackService->getEntryFeedback($entryId);
     }

--- a/src/variables/FeedbackVariable.php
+++ b/src/variables/FeedbackVariable.php
@@ -33,29 +33,6 @@ class FeedbackVariable
     // Public Methods
     // =========================================================================
 
-//    /**
-//     * createFeedbackRecord
-//     *
-//     * @param FeedbackModel $feedback
-//     * @return bool
-//     */
-//    public function createFeedbackRecord(FeedbackModel $feedback): bool
-//    {
-//        return Feedback::$plugin->feedbackService->createFeedbackRecord($feedback);
-//    }
-
-//    /**
-//     * updateFeedbackRecord
-//     *
-//     * @param int $feedbackId
-//     * @param array $attributes
-//     * @return bool
-//     */
-//    public function updateFeedbackRecord(int $feedbackId, array $attributes): bool
-//    {
-//        return Feedback::$plugin->feedbackService->updateFeedbackRecord($feedbackId, $attributes);
-//    }
-
     /**
      * getEntryFeedback
      *


### PR DESCRIPTION
## 1.0.11 - 2021-08-18
### Fixed
- Fixed issue where `getEntryFeedback()` service was using `.all()` which was limiting the use of `paginate` on the frontend templates.
- Frontend templates can now use `.feedbackType()` alongside the service.
